### PR TITLE
Show story template before ready

### DIFF
--- a/game.js
+++ b/game.js
@@ -487,6 +487,9 @@ async function startCameraAndConnect() {
     
     localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
 
+    const videoGrid = document.getElementById("videoGrid");
+    videoGrid.style.display = "flex"; // 🎥 ビデオ領域を表示
+
     const video = document.createElement("video");
     video.srcObject = localStream;
     video.autoplay = true;
@@ -495,7 +498,7 @@ async function startCameraAndConnect() {
     video.style.width = "200px";
     video.style.height = "150px";
     video.style.margin = "10px";
-    document.getElementById("videoGrid").appendChild(video);
+    videoGrid.appendChild(video);
     await video.play().catch(e => console.warn("ローカル再生エラー:", e));
 
     console.log("📷 ローカルカメラ取得完了");
@@ -555,6 +558,9 @@ async function createConnectionWith(remoteUID) {
       console.log(`📺 ${remoteUID}の既存ビデオ要素を削除しました`);
     }
     
+    const videoGrid = document.getElementById("videoGrid");
+    videoGrid.style.display = "flex"; // 🎥 リモート映像表示用に表示
+
     const remoteVideo = document.createElement("video");
     remoteVideo.setAttribute("data-user-id", remoteUID); // 🔧 追加：識別子を追加
     remoteVideo.srcObject = event.streams[0];
@@ -563,7 +569,7 @@ async function createConnectionWith(remoteUID) {
     remoteVideo.style.width = "200px";
     remoteVideo.style.height = "150px"; // 🔧 追加：高さも指定
     remoteVideo.style.margin = "10px";
-    document.getElementById("videoGrid").appendChild(remoteVideo);
+    videoGrid.appendChild(remoteVideo);
     remoteVideo.play().catch(e => console.warn("再生エラー:", e));
   };
 

--- a/game.js
+++ b/game.js
@@ -309,22 +309,10 @@ window.addEventListener("beforeunload", async (event) => {
 document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "hidden" && !isPageUnloading) {
     console.warn("⚠️ ページが非表示になりました（タブ切り替えなど）");
-    // 🔧 修正：強制的にページ移動はしない
-    // window.location.href = "index.html"; // この行をコメントアウト
-    
-    // 必要に応じて一時停止処理
-    if (timerInterval) {
-      clearInterval(timerInterval);
-      console.log("⏸️ タイマーを一時停止しました");
-    }
+    // 以前はここでタイマーを停止していましたが、
+    // タブを切り替えてもタイマーが止まらないように変更
   } else if (document.visibilityState === "visible") {
     console.log("👁️ ページが再表示されました");
-    
-    // タイマー再開処理
-    if (timerStarted && !timerInterval && remainingSeconds > 0) {
-      startCountdown();
-      console.log("▶️ タイマーを再開しました");
-    }
   }
 });
 
@@ -392,6 +380,7 @@ case 0:
 
         textboxContainer.style.display = "block";
         bottomUI.style.display = "flex";
+        showStoryTemplate();
         startCountdown();
 
         readyButton.addEventListener("click", async () => {
@@ -399,6 +388,9 @@ case 0:
           if (!uid) return;
           await set(ref(db, `rooms/${roomCode}/players/${uid}/ready`), true);
           readyButton.classList.add("disabled");
+          if (!cameraStarted) {
+            await startCameraAndConnect();
+          }
         });
 
         onValue(ref(db, `rooms/${roomCode}/players`), (snapshot) => {
@@ -407,6 +399,11 @@ case 0:
 
           const allReady = Object.values(players).every(p => p.ready);
           if (allReady) {
+            if (timerInterval) {
+              clearInterval(timerInterval);
+              timerInterval = null;
+              timerStarted = false;
+            }
             triggerStoryOutput();
           }
         });
@@ -429,6 +426,7 @@ case 0:
 }
 
 let storyAlreadyOutput = false;
+let currentStoryTemplate = ""; // store template to avoid regeneration
 async function triggerStoryOutput() {
   if (storyAlreadyOutput) return;
   storyAlreadyOutput = true;
@@ -456,15 +454,16 @@ async function triggerStoryOutput() {
         overlay.removeEventListener("transitionend", handleFadeOut);
         overlay.style.pointerEvents = "none";
 
-        // ✅ 怪談を出力
-        const generated = generateStoryTemplate();
-        console.log("🎃 出力テンプレート:", generated);
-        const box = document.getElementById("storyTemplate");
-        box.innerHTML = generated;
-        container.style.display = "block";
+        // ✅ 怪談を出力（テンプレートは保持のみ）
+        if (!currentStoryTemplate) {
+          currentStoryTemplate = generateStoryTemplate();
+          console.log("🎃 出力テンプレート:", currentStoryTemplate);
+        }
+
+        container.innerHTML = "";
+        container.style.display = "none";
 
         videoGrid.style.display = "flex";
-        await startCameraForCurrentUser();
         await startCameraAndConnect();
       });
     }, 1000);
@@ -474,8 +473,14 @@ async function triggerStoryOutput() {
 
 const peerConnections = {};
 let localStream = null;
+let cameraStarted = false;
 
 async function startCameraAndConnect() {
+  if (cameraStarted) {
+    console.log("📷 カメラは既に起動しています");
+    return;
+  }
+  cameraStarted = true;
   try {
     // 🔧 追加：開始前に既存の接続をクリーンアップ
     await cleanupWebRTCConnections();
@@ -763,16 +768,18 @@ function generateStoryTemplate() {
     .join("");
 }
 
-function triggerBlankStoryOutput() {
-  if (storyAlreadyOutput) return;
-  storyAlreadyOutput = true;
-
+function showStoryTemplate() {
   const container = document.getElementById("textboxContainer");
-  const story = generateStoryTemplate();
+  const playerList = document.getElementById("playerList");
+  const actionTitle = document.getElementById("actionTitle");
+  currentStoryTemplate = generateStoryTemplate();
+
+  if (playerList) playerList.style.display = "none";
+  if (actionTitle) actionTitle.style.display = "none";
 
   container.innerHTML = `
     <h2 style="font-size: 28px; margin-bottom: 20px;">あなたの怪談を完成させましょう</h2>
-    <div id="storyTemplate">${story}</div>
+    <div id="storyTemplate">${currentStoryTemplate}</div>
   `;
 
   container.style.display = "block";


### PR DESCRIPTION
## Summary
- display the story template as soon as the ready UI appears
- keep the same template when the story phase starts
- hide the template and header once the camera is active
- hide name order while the template is shown
- keep countdown running on tab switches
- stop the timer once all players become ready
- start the camera when Ready is clicked and prevent duplicates

## Testing
- `npm test` *(fails: package.json missing)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873011a1fa08323beeae47f3ec13114